### PR TITLE
feat: customize mega menu with props

### DIFF
--- a/src/components/headers/header-mega-menu/header-mega-menu.module.scss
+++ b/src/components/headers/header-mega-menu/header-mega-menu.module.scss
@@ -22,7 +22,7 @@
     width: 100%;
   }
 
-  @mixin hover {
+  &:hover {
     background-color: light-dark(
       var(--mantine-color-gray-0),
       var(--mantine-color-dark-6)
@@ -35,7 +35,7 @@
   padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
   border-radius: var(--mantine-radius-md);
 
-  @mixin hover {
+  &:hover {
     background-color: light-dark(
       var(--mantine-color-gray-0),
       var(--mantine-color-dark-7)

--- a/src/components/headers/header-mega-menu/header-mega-menu.tsx
+++ b/src/components/headers/header-mega-menu/header-mega-menu.tsx
@@ -18,72 +18,38 @@ import {
   useMantineTheme,
 } from "@mantine/core"
 import { useDisclosure } from "@mantine/hooks"
-import {
-  IconNotification,
-  IconCode,
-  IconBook,
-  IconChartPie3,
-  IconFingerprint,
-  IconCoin,
-  IconChevronDown,
-} from "@tabler/icons-react"
+import { IconChevronDown } from "@tabler/icons-react"
 import classes from "./header-mega-menu.module.scss"
 import { HeaderWithMegaMenuProps } from "./header-mega-menu.types"
 
-const mockdata = [
-  {
-    icon: IconCode,
-    title: "Open source",
-    description: "This Pokémon’s cry is very loud and distracting",
-  },
-  {
-    icon: IconCoin,
-    title: "Free for everyone",
-    description: "The fluid of Smeargle’s tail secretions changes",
-  },
-  {
-    icon: IconBook,
-    title: "Documentation",
-    description: "Yanma is capable of seeing 360 degrees without",
-  },
-  {
-    icon: IconFingerprint,
-    title: "Security",
-    description: "The shell’s rounded shape and the grooves on its.",
-  },
-  {
-    icon: IconChartPie3,
-    title: "Analytics",
-    description: "This Pokémon uses its flying ability to quickly chase",
-  },
-  {
-    icon: IconNotification,
-    title: "Notifications",
-    description: "Combusken battles with the intensely hot flames it spews",
-  },
-]
-
-export function HeaderMegaMenu({ button }: HeaderWithMegaMenuProps) {
+export function HeaderMegaMenu({
+  primaryButtonProps,
+  primaryButtontitle = "Log In",
+  secondaryButtonProps,
+  secondarybuttontitle = "Sign Up",
+  subMenuItems,
+  menuItems,
+}: HeaderWithMegaMenuProps) {
   const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] =
     useDisclosure(false)
   const [linksOpened, { toggle: toggleLinks }] = useDisclosure(false)
   const theme = useMantineTheme()
 
-  const links = mockdata.map((item) => (
-    <UnstyledButton className={classes.subLink} key={item.title}>
+  const links = subMenuItems.map((subItem) => (
+    <UnstyledButton className={classes.subLink} key={subItem.title}>
       <Group wrap="nowrap" align="flex-start">
         <ThemeIcon size={34} variant="default" radius="md">
-          <item.icon
+          <subItem.icon
             style={{ width: rem(22), height: rem(22) }}
             color={theme.colors.blue[6]}
           />
         </ThemeIcon>
         <div>
           <Text size="sm" fw={500}>
-            {item.title}
+            {subItem.title}
           </Text>
           <Text size="xs" c="dimmed">
-            {item.description}
+            {subItem.description}
           </Text>
         </div>
       </Group>
@@ -95,72 +61,76 @@ export function HeaderMegaMenu({ button }: HeaderWithMegaMenuProps) {
       <header className={classes.header}>
         <Group justify="space-between" h="100%">
           <Group h="100%" gap={0} visibleFrom="sm">
-            <a href="#" className={classes.link}>
-              Home
-            </a>
-            <HoverCard
-              width={600}
-              position="bottom"
-              radius="md"
-              shadow="md"
-              withinPortal
-            >
-              <HoverCard.Target>
-                <a href="#" className={classes.link}>
-                  <Center inline>
-                    <Box component="span" mr={5}>
-                      Features
-                    </Box>
-                    <IconChevronDown
-                      style={{ width: rem(16), height: rem(16) }}
-                      color={theme.colors.blue[6]}
-                    />
-                  </Center>
-                </a>
-              </HoverCard.Target>
+            {menuItems.map((item) => {
+              return (
+                <>
+                  {item.isSubMenu ? (
+                    <HoverCard
+                      width={600}
+                      position="bottom"
+                      radius="md"
+                      shadow="md"
+                      withinPortal
+                    >
+                      <HoverCard.Target>
+                        <a href="#" className={classes.link}>
+                          <Center inline>
+                            <Box component="span" mr={5}>
+                              Features
+                            </Box>
+                            <IconChevronDown
+                              style={{ width: rem(16), height: rem(16) }}
+                              color={theme.colors.blue[6]}
+                            />
+                          </Center>
+                        </a>
+                      </HoverCard.Target>
 
-              <HoverCard.Dropdown style={{ overflow: "hidden" }}>
-                <Group justify="space-between" px="md">
-                  <Text fw={500}>Features</Text>
-                  <Anchor href="#" fz="xs">
-                    View all
-                  </Anchor>
-                </Group>
+                      <HoverCard.Dropdown style={{ overflow: "hidden" }}>
+                        <Group justify="space-between" px="md">
+                          <Text fw={500}>Features</Text>
+                          <Anchor href="#" fz="xs">
+                            View all
+                          </Anchor>
+                        </Group>
 
-                <Divider my="sm" />
+                        <Divider my="sm" />
 
-                <SimpleGrid cols={2} spacing={0}>
-                  {links}
-                </SimpleGrid>
+                        <SimpleGrid cols={2} spacing={0}>
+                          {links}
+                        </SimpleGrid>
 
-                <div className={classes.dropdownFooter}>
-                  <Group justify="space-between">
-                    <div>
-                      <Text fw={500} fz="sm">
-                        Get started
-                      </Text>
-                      <Text size="xs" c="dimmed">
-                        Their food sources have decreased, and their numbers
-                      </Text>
-                    </div>
-                    <Button variant="default">Get started</Button>
-                  </Group>
-                </div>
-              </HoverCard.Dropdown>
-            </HoverCard>
-            <a href="#" className={classes.link}>
-              Learn
-            </a>
-            <a href="#" className={classes.link}>
-              Academy
-            </a>
+                        <div className={classes.dropdownFooter}>
+                          <Group justify="space-between">
+                            <div>
+                              <Text fw={500} fz="sm">
+                                Get started
+                              </Text>
+                              <Text size="xs" c="dimmed">
+                                Their food sources have decreased, and their
+                                numbers
+                              </Text>
+                            </div>
+                            <Button variant="default">Get started</Button>
+                          </Group>
+                        </div>
+                      </HoverCard.Dropdown>
+                    </HoverCard>
+                  ) : (
+                    <a href="#" className={classes.link}>
+                      {item.title}
+                    </a>
+                  )}
+                </>
+              )
+            })}
           </Group>
 
           <Group visibleFrom="sm">
-            <Button variant="default" {...button}>
-              Log in
+            <Button variant="default" {...primaryButtonProps}>
+              {primaryButtontitle}
             </Button>
-            <Button>Sign up</Button>
+            <Button {...secondaryButtonProps}>{secondarybuttontitle}</Button>
           </Group>
 
           <Burger
@@ -182,28 +152,35 @@ export function HeaderMegaMenu({ button }: HeaderWithMegaMenuProps) {
       >
         <ScrollArea h={`calc(100vh - ${rem(80)})`} mx="-md">
           <Divider my="sm" />
-
-          <a href="#" className={classes.link}>
-            Home
-          </a>
-          <UnstyledButton className={classes.link} onClick={toggleLinks}>
-            <Center inline>
-              <Box component="span" mr={5}>
-                Features
-              </Box>
-              <IconChevronDown
-                style={{ width: rem(16), height: rem(16) }}
-                color={theme.colors.blue[6]}
-              />
-            </Center>
-          </UnstyledButton>
-          <Collapse in={linksOpened}>{links}</Collapse>
-          <a href="#" className={classes.link}>
-            Learn
-          </a>
-          <a href="#" className={classes.link}>
-            Academy
-          </a>
+          {menuItems.map((item) => {
+            return (
+              <>
+                {item.isSubMenu ? (
+                  <>
+                    <UnstyledButton
+                      className={classes.link}
+                      onClick={toggleLinks}
+                    >
+                      <Center inline>
+                        <Box component="span" mr={5}>
+                          Features
+                        </Box>
+                        <IconChevronDown
+                          style={{ width: rem(16), height: rem(16) }}
+                          color={theme.colors.blue[6]}
+                        />
+                      </Center>
+                    </UnstyledButton>
+                    <Collapse in={linksOpened}>{links}</Collapse>
+                  </>
+                ) : (
+                  <a href="#" className={classes.link}>
+                    {item.title}
+                  </a>
+                )}
+              </>
+            )
+          })}
 
           <Divider my="sm" />
 

--- a/src/components/headers/header-mega-menu/header-mega-menu.tsx
+++ b/src/components/headers/header-mega-menu/header-mega-menu.tsx
@@ -76,7 +76,7 @@ export function HeaderMegaMenu({
                         <a href="#" className={classes.link}>
                           <Center inline>
                             <Box component="span" mr={5}>
-                              Features
+                              {item.title}
                             </Box>
                             <IconChevronDown
                               style={{ width: rem(16), height: rem(16) }}
@@ -88,7 +88,7 @@ export function HeaderMegaMenu({
 
                       <HoverCard.Dropdown style={{ overflow: "hidden" }}>
                         <Group justify="space-between" px="md">
-                          <Text fw={500}>Features</Text>
+                          <Text fw={500}>{item.title}</Text>
                           <Anchor href="#" fz="xs">
                             View all
                           </Anchor>
@@ -127,10 +127,10 @@ export function HeaderMegaMenu({
           </Group>
 
           <Group visibleFrom="sm">
-            <Button variant="default" {...primaryButtonProps}>
-              {primaryButtontitle}
+            <Button variant="default" {...secondaryButtonProps}>
+              {secondarybuttontitle}
             </Button>
-            <Button {...secondaryButtonProps}>{secondarybuttontitle}</Button>
+            <Button {...primaryButtonProps}>{primaryButtontitle}</Button>
           </Group>
 
           <Burger
@@ -185,8 +185,10 @@ export function HeaderMegaMenu({
           <Divider my="sm" />
 
           <Group justify="center" grow pb="xl" px="md">
-            <Button variant="default">Log in</Button>
-            <Button>Sign up</Button>
+            <Button variant="default" {...secondaryButtonProps}>
+              {secondarybuttontitle}
+            </Button>
+            <Button {...primaryButtonProps}>{primaryButtontitle}</Button>
           </Group>
         </ScrollArea>
       </Drawer>

--- a/src/components/headers/header-mega-menu/header-mega-menu.types.ts
+++ b/src/components/headers/header-mega-menu/header-mega-menu.types.ts
@@ -1,6 +1,23 @@
 import { type ButtonProps } from "@mantine/core"
 
-export type HeaderWithMegaMenuProps = {
+interface ISubMenudata {
+  // Todo: Discuss type for icons
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: any
   title: string
-  button: ButtonProps
+  description: string
+}
+
+interface ImenuData {
+  title: string
+  isSubMenu: boolean
+}
+
+export type HeaderWithMegaMenuProps = {
+  primaryButtontitle?: string
+  primaryButtonProps?: ButtonProps
+  secondarybuttontitle?: string
+  secondaryButtonProps?: ButtonProps
+  subMenuItems: ISubMenudata[]
+  menuItems: ImenuData[]
 }

--- a/src/stories/header-mega-menu.stories.ts
+++ b/src/stories/header-mega-menu.stories.ts
@@ -1,5 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react"
-
+import {
+  IconNotification,
+  IconCode,
+  IconBook,
+  IconChartPie3,
+  IconFingerprint,
+  IconCoin,
+} from "@tabler/icons-react"
 import { HeaderMegaMenu } from "@components/headers"
 
 const meta = {
@@ -10,14 +17,64 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const subMenuMockdata = [
+  {
+    icon: IconCode,
+    title: "Open source",
+    description: "This Pokémon’s cry is very loud and distracting",
+  },
+  {
+    icon: IconCoin,
+    title: "Free for everyone",
+    description: "The fluid of Smeargle’s tail secretions changes",
+  },
+  {
+    icon: IconBook,
+    title: "Documentation",
+    description: "Yanma is capable of seeing 360 degrees without",
+  },
+  {
+    icon: IconFingerprint,
+    title: "Security",
+    description: "The shell’s rounded shape and the grooves on its.",
+  },
+  {
+    icon: IconChartPie3,
+    title: "Analytics",
+    description: "This Pokémon uses its flying ability to quickly chase",
+  },
+  {
+    icon: IconNotification,
+    title: "Notifications",
+    description: "Combusken battles with the intensely hot flames it spews",
+  },
+]
+
+const menuMockData = [
+  {
+    title: "Home",
+    isSubMenu: false,
+  },
+  {
+    title: "Features",
+    isSubMenu: true,
+  },
+]
+
 export const Default: Story = {
   args: {
-    title: "Menu",
-    button: {
+    primaryButtonProps: {
+      style: {
+        color: "red",
+      },
+    },
+    secondaryButtonProps: {
       variant: "filled",
       style: {
         color: "red",
       },
     },
+    menuItems: menuMockData,
+    subMenuItems: subMenuMockdata,
   },
 }


### PR DESCRIPTION
## Description

Add customizable header with mega menu

## Screenshots and Videos

<img width="968" alt="Screenshot 2024-07-03 at 8 56 19 AM" src="https://github.com/ravnhq/Mantine-UI/assets/63429867/5cca0fd0-ae0f-40f7-9fe4-2c0941d56b2f">


## Check those that apply

- [x] My changes have been manually tested and verified.
- [ ] My changes affect the DB schema
- [ ] I have written a database migration script for my changes.
- [ ] My changes update dependencies
- [ ] My changes remove dependencies
