### PR TITLE
feat(MANUI-5): Add custom hero component with content left

### DIFF
--- a/src/components/hero/hero-content-left/hero-content-left.module.scss
+++ b/src/components/hero/hero-content-left/hero-content-left.module.scss
@@ -1,0 +1,57 @@
+.hero {
+  position: relative;
+  background-image: url(https://images.unsplash.com/photo-1519389950473-47ba0277781c?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80);
+  background-size: cover;
+  background-position: center;
+}
+
+.container {
+  height: toRem(700px);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-start;
+  padding-bottom: calc(var(--mantine-spacing-xl) * 6);
+  z-index: 1;
+  position: relative;
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    height: toRem(500px);
+    padding-bottom: calc(var(--mantine-spacing-xl) * 3);
+  }
+}
+
+.title {
+  color: var(--mantine-color-white);
+  font-size: toRem(60px);
+  font-weight: 900;
+  line-height: 1.1;
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    font-size: toRem(40px);
+    line-height: 1.2;
+  }
+
+  @media (max-width: $mantine-breakpoint-xs) {
+    font-size: toRem(28px);
+    line-height: 1.3;
+  }
+}
+
+.description {
+  color: var(--mantine-color-white);
+  max-width: toRem(600px);
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    max-width: 100%;
+    font-size: var(--mantine-font-size-sm);
+  }
+}
+
+.control {
+  margin-top: calc(var(--mantine-spacing-xl) * 1.5);
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    width: 100%;
+  }
+}

--- a/src/components/hero/hero-content-left/hero-content-left.tsx
+++ b/src/components/hero/hero-content-left/hero-content-left.tsx
@@ -1,0 +1,35 @@
+import classes from "./hero-content-left.module.scss"
+import { HeroContentLeftProps } from "./hero-content-left.types"
+import { Container, Overlay, Text, Title } from "@mantine/core"
+
+export function HeroContentLeft({
+  title,
+  description,
+  children,
+  descriptionProps,
+  titleProps,
+}: HeroContentLeftProps) {
+  return (
+    <div className={classes.hero}>
+      <Overlay
+        gradient="linear-gradient(180deg, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, .65) 40%)"
+        opacity={1}
+        zIndex={0}
+      />
+      <Container className={classes.container} size="md">
+        <Title className={classes.title} {...titleProps}>
+          {title}
+        </Title>
+        <Text
+          className={classes.description}
+          size="xl"
+          mt="xl"
+          {...descriptionProps}
+        >
+          {description}
+        </Text>
+        {children}
+      </Container>
+    </div>
+  )
+}

--- a/src/components/hero/hero-content-left/hero-content-left.types.ts
+++ b/src/components/hero/hero-content-left/hero-content-left.types.ts
@@ -1,0 +1,10 @@
+import { TextProps, TitleProps } from "@mantine/core"
+import { ReactNode } from "react"
+
+export interface HeroContentLeftProps {
+  title?: string
+  titleProps?: TitleProps
+  description?: string
+  descriptionProps?: TextProps
+  children?: ReactNode
+}

--- a/src/components/hero/hero-content-left/index.ts
+++ b/src/components/hero/hero-content-left/index.ts
@@ -1,0 +1,1 @@
+export { HeroContentLeft } from "./hero-content-left"

--- a/src/components/hero/index.ts
+++ b/src/components/hero/index.ts
@@ -1,0 +1,1 @@
+export * from "./hero-content-left"

--- a/src/stories/hero-content-left.stories.tsx
+++ b/src/stories/hero-content-left.stories.tsx
@@ -1,0 +1,28 @@
+import { HeroContentLeft } from "@components/hero"
+import { Button } from "@mantine/core"
+import { Meta, StoryObj } from "@storybook/react/*"
+
+const meta = {
+  component: HeroContentLeft,
+} satisfies Meta<typeof HeroContentLeft>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    title: "Hero With content left",
+    description: "A Hero component with content left",
+    titleProps: {
+      style: {
+        color: "#F2F2F2",
+      },
+    },
+    children: (
+      <Button variant="gradient" size="xl" radius="xl" my={12}>
+        Button
+      </Button>
+    ),
+  },
+}


### PR DESCRIPTION
## Description

Add custom Hero component with content left, with title, description, children props

## Screenshots and Videos

<img width="1185" alt="Screenshot 2024-07-08 at 12 13 03 PM" src="https://github.com/ravnhq/Mantine-UI/assets/63429867/6bc1535a-94f8-4d02-b8b5-11150a07624c">

## Check those that apply

- [x] My changes have been manually tested and verified.
- [ ] My changes affect the DB schema
- [ ] I have written a database migration script for my changes.
- [ ] My changes update dependencies
- [ ] My changes remove dependencies
