### PR TITLE
feat(MANUI-6): Add comment component with html content

### DIFF
--- a/src/components/comments/comment-html-content/comment-html-content.module.scss
+++ b/src/components/comments/comment-html-content/comment-html-content.module.scss
@@ -1,0 +1,15 @@
+.comment {
+  padding: var(--mantine-spacing-lg) var(--mantine-spacing-xl);
+}
+
+.body {
+  padding-left: toRem(54px);
+  padding-top: var(--mantine-spacing-sm);
+  font-size: var(--mantine-font-size-sm);
+}
+
+.content {
+  & > p:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/src/components/comments/comment-html-content/comment-html-content.tsx
+++ b/src/components/comments/comment-html-content/comment-html-content.tsx
@@ -1,0 +1,26 @@
+import classes from "./comment-html-content.module.scss"
+import { CommentHtmlContentProps } from "./comment-html-content.types"
+import { Group, Paper, TypographyStylesProvider } from "@mantine/core"
+
+export function CommentHtml({
+  icon,
+  titleContent,
+  htmlContent = "",
+}: CommentHtmlContentProps) {
+  return (
+    <Paper withBorder radius="md" className={classes.comment}>
+      <Group>
+        {icon}
+        <div>{titleContent}</div>
+      </Group>
+      <TypographyStylesProvider className={classes.body}>
+        <div
+          className={classes.content}
+          dangerouslySetInnerHTML={{
+            __html: `${htmlContent}`,
+          }}
+        />
+      </TypographyStylesProvider>
+    </Paper>
+  )
+}

--- a/src/components/comments/comment-html-content/comment-html-content.types.ts
+++ b/src/components/comments/comment-html-content/comment-html-content.types.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from "react"
+
+export interface CommentHtmlContentProps {
+  icon?: ReactNode
+  titleContent?: ReactNode
+  htmlContent?: string
+}

--- a/src/components/comments/comment-html-content/index.ts
+++ b/src/components/comments/comment-html-content/index.ts
@@ -1,0 +1,1 @@
+export { CommentHtml } from "./comment-html-content"

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -1,0 +1,1 @@
+export * from "./comment-html-content"

--- a/src/stories/comment-html-content.stories.tsx
+++ b/src/stories/comment-html-content.stories.tsx
@@ -1,0 +1,38 @@
+import { CommentHtml } from "@components/comments"
+import { Avatar, Text } from "@mantine/core"
+import { Meta, StoryObj } from "@storybook/react"
+
+const meta = {
+  component: CommentHtml,
+} satisfies Meta<typeof CommentHtml>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const htmlTest = `<p>I use <a href="https://heroku.com/" rel="noopener noreferrer" target="_blank">Heroku</a> to host my Node.js application, but MongoDB add-on appears to be too <strong>expensive</strong>. I consider switching to <a href="https://www.digitalocean.com/" rel="noopener noreferrer" target="_blank">Digital Ocean</a> VPS to save some cash.</p>`
+
+const iconTest = (
+  <Avatar
+    src="https://raw.githubusercontent.com/mantinedev/mantine/master/.demo/avatars/avatar-2.png"
+    alt="Jacob Warnhalter"
+    radius="xl"
+  />
+)
+
+const titleTest = (
+  <>
+    <Text fz="sm">Jacob Warnhalter</Text>
+    <Text fz="xs" c="dimmed">
+      10 minutes ago
+    </Text>
+  </>
+)
+
+export const Default: Story = {
+  args: {
+    icon: iconTest,
+    htmlContent: htmlTest,
+    titleContent: titleTest,
+  },
+}


### PR DESCRIPTION
## Description

Add comment component with html content, title, and icon props

## Screenshots and Videos

<img width="402" alt="Screenshot 2024-07-08 at 5 38 08 PM" src="https://github.com/ravnhq/Mantine-UI/assets/63429867/9c7d6e9e-5373-4a70-ad25-6d150b5c9983">


## Check those that apply

- [x] My changes have been manually tested and verified.
- [ ] My changes affect the DB schema
- [ ] I have written a database migration script for my changes.
- [ ] My changes update dependencies
- [ ] My changes remove dependencies
